### PR TITLE
Implement attribute value bypass via parent path

### DIFF
--- a/lib/rules/no-whitespace-within-word.js
+++ b/lib/rules/no-whitespace-within-word.js
@@ -105,29 +105,11 @@ function splitTextByEntity(input) {
 module.exports = class NoWhitespaceWithinWord extends Rule {
   visitor() {
     return {
-      Program: {
-        enter() {
-          this.attrNodeCount = 0;
-        },
-        exit() {
-          delete this.attrNodeCount;
-        },
-      },
-
-      AttrNode: {
-        enter() {
-          this.attrNodeCount++;
-        },
-        exit() {
-          this.attrNodeCount--;
-        },
-      },
-
-      TextNode(node) {
-        if (this.attrNodeCount > 0) {
+      TextNode(node, path) {
+        let parents = [...path.parents()];
+        if (parents.find((parent) => parent.node.type === 'AttrNode')) {
           return;
         }
-
         let alternationCount = 0;
         let source = this.sourceForNode(node);
         let characters = splitTextByEntity(source);


### PR DESCRIPTION
Related: #1496 #1497

If merged, this PR refactors the implementation used to bypass `TextNodes` that are attribute values in the proposed patch (#1497) to the existing `no-whitespace-within-word` rule. There is no (intentional) change to the overall logic of the bypass -- that is, the `TextNode` should not be evaluated for the rule's logic if it is contained within an `AttrNode`. 

Specifically, rather than tracking whether or not an `AttrNode` has been `visited` AND `entered` but NOT `exited` *while en-route* to `visiting` the `TextNode` in question, this implementation *only* `visits` the `TextNode` directly. *However*, it also provides that `TextNodes`'s source `path` of parent nodes as input. The `path` of parent nodes is then iterated recursively towards its root, checking along the way to see if any of those parents are an `AttrNode`. If an `AttrNode` parent is found, the bypass will be triggered for the original `TextNode`.